### PR TITLE
Enhancement: move urls into env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,10 @@ npm-debug.log
 yarn-error.log
 testem.log
 /typings
+
+# env
 serverless-functions/.env
+src/environments/environment.prod.ts
 
 # System Files
 .DS_Store

--- a/src/app/services/experience.service.ts
+++ b/src/app/services/experience.service.ts
@@ -3,11 +3,11 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-import { CheckHttps } from '../utils/detect-protocol';
+import { environment } from 'src/environments/environment';
 import { HttpErrorHandler } from '../utils/http-error-handler.util';
 import { Experience } from '../models/experience';
 
-const URL : string = CheckHttps() ? 'https://michie-portfolio.netlify.app/skills' : 'http://localhost:8888/skills';
+const URL : string = `${environment.API_BASE_URL}/experience`;
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -3,11 +3,11 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-import { CheckHttps } from '../utils/detect-protocol';
+import { environment } from 'src/environments/environment';
 import { HttpErrorHandler } from '../utils/http-error-handler.util';
 import { Project } from '../models/project';
 
-const URL : string = CheckHttps() ? 'https://michie-portfolio.netlify.app/projects' : 'http://localhost:8888/projects';
+const URL : string = `${environment.API_BASE_URL}/projects`;
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/services/skill.service.ts
+++ b/src/app/services/skill.service.ts
@@ -3,11 +3,11 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-import { CheckHttps } from '../utils/detect-protocol';
+import { environment } from 'src/environments/environment';
 import { HttpErrorHandler } from '../utils/http-error-handler.util';
 import { Skill } from '../models/skill';
 
-const URL : string = CheckHttps() ? 'https://michie-portfolio.netlify.app/skills' : 'http://localhost:8888/skills';
+const URL : string = `${environment.API_BASE_URL}/skills`;
 
 @Injectable({
   providedIn: 'root'

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,0 @@
-export const environment = {
-  production: true
-};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,16 +1,4 @@
-// This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
-// The list of file replacements can be found in `angular.json`.
-
 export const environment = {
-  production: false
+  production: false,
+  API_BASE_URL: 'http://localhost:8888'
 };
-
-/*
- * For easier debugging in development mode, you can import the following file
- * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
- *
- * This import should be commented out in production mode because it will have a negative impact
- * on performance if an error is thrown.
- */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.


### PR DESCRIPTION
Instead of using the CheckHttps utility to determine the correct API endpoint, utilize dev/prod environment variables.